### PR TITLE
5 sigma cut on Rochester corrections

### DIFF
--- a/interface/muresolution_run2.h
+++ b/interface/muresolution_run2.h
@@ -133,8 +133,11 @@ public:
 				int     D = getBin(v, NTRK, dtrk[H]);
 				double RD = kDat[H] * Sigma(pt, H, D);
 				double RM = kRes[H] * Sigma(pt, H, F);
-				if(RD > RM) x = sqrt(RD * RD - RM * RM) * cb[H][F].invcdf(u);
-				else      x = 0;
+				if(RD>RM){
+				  double rn = cb[H][F].invcdf(u);
+				  if(fabs(rn)>5.0) rn = 0.0;
+				  x = sqrt(RD*RD-RM*RM)*rn;
+				}else      x = 0;
 			} else if(type == Data) x = kDat[H] * Sigma(pt, H, F) * cb[H][F].invcdf(u);
 			else		  x = kRes[H] * Sigma(pt, H, F) * cb[H][F].invcdf(u);
 		}


### PR DESCRIPTION
5 sigma cut added to smearing in the Rochester corrections as suggested by the Rochester group.
